### PR TITLE
Added translations link for FeedReader

### DIFF
--- a/apps/FeedReader.md
+++ b/apps/FeedReader.md
@@ -21,6 +21,8 @@ links:
     url: jangernert/FeedReader
   - type: Launchpad
     url: feedreader
+  - type: Translations
+    url : "https://www.transifex.com/dev-feedreader/feedreader/"
   - type: License
     url: "http://bazaar.launchpad.net/~eviltwin1/feedreader/master/view/head:/COPYING"
 


### PR DESCRIPTION
I added translations link for FeedReader as we moved from Launchpad to Github and we use Transifex for translations instead of Launchpad translations!
You can close this if you think there's no need to have it :+1: 
