### PR TITLE
Add Transfer.sh Contract

### DIFF
--- a/apps/Transfer.sh Contract.md
+++ b/apps/Transfer.sh Contract.md
@@ -1,0 +1,27 @@
+---
+
+layout: app
+created: 2017-01-04
+updated: 2017-01-04
+
+permalink: /Transfer.sh Contract/
+generic: uploader extension
+description: A Contractor plugin for uploading to Transfer.sh with a single click.
+license: GPL v3
+
+authors:
+  - name: Tomáš Martykán
+    url: 'https://github.com/martykan'
+    mail: 't.martykan@gmail.com'
+  - name: Stefan Ric (cybre)
+    url: 'https://github.com/cybre'
+    mail: 'stfric369@gmail.com'
+
+links:
+  - type: GitHub
+    url: martykan/transfersh-contract
+  - type: Readme
+    url: 'https://github.com/martykan/transfersh-contract/blob/master/README.md'
+  - type: License
+    url: 'https://github.com/martykan/transfersh-contract/blob/master/LICENSE'
+---


### PR DESCRIPTION
A fork of Hastebin Contract to upload any file to Transfer.sh. No screenshot because it doesn't really have any UI