### PR TITLE
Fix NaSC apt package name

### DIFF
--- a/apps/NaSC.md
+++ b/apps/NaSC.md
@@ -27,7 +27,7 @@ installation:
     info:
     - version: 0.3
       repository: 'ppa:nasc-team/daily'
-      package: nasc
+      package: com.github.parnold-x.nasc
       type: daily
 ---
 


### PR DESCRIPTION
package `nasc` doesn't exist. Using package name `com.github.parnold-x.nasc` following official website installation instructions at https://parnold-x.github.io/nasc/#installation